### PR TITLE
Custom pan recognizer + loading widget

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.0+1"
+    version: "0.6.1"
   crypto:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -169,7 +169,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:

--- a/lib/crop_your_image.dart
+++ b/lib/crop_your_image.dart
@@ -3,11 +3,16 @@ library crop_your_image;
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:crop_your_image/src/detectors/custom_pan_detector.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as image;
 
-part 'src/crop.dart';
-part 'src/controller.dart';
 part 'src/calculator.dart';
+
+part 'src/controller.dart';
+
+part 'src/crop.dart';
+
 part 'src/edge_alignment.dart';

--- a/lib/src/detectors/custom_pan_detector.dart
+++ b/lib/src/detectors/custom_pan_detector.dart
@@ -1,0 +1,47 @@
+import 'package:crop_your_image/src/recognizers/custom_pan_recognizer.dart';
+import 'package:flutter/widgets.dart';
+
+class CustomPanDetector extends StatelessWidget {
+  final Widget child;
+  final Function(Offset offset)? onPanDown;
+  final Function(Offset delta)? onPanUpdate;
+  final Function()? onPanEnd;
+
+  const CustomPanDetector({
+    Key? key,
+    required this.child,
+    this.onPanDown,
+    this.onPanUpdate,
+    this.onPanEnd,
+  }) : super(key: key);
+
+  void _onPanDown(Offset offset) {
+    this.onPanDown?.call(offset);
+  }
+
+  void _onPanUpdate(Offset delta) {
+    this.onPanUpdate?.call(delta);
+  }
+
+  void _onPanEnd(_) {
+    this.onPanEnd?.call();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RawGestureDetector(
+      gestures: {
+        CustomPanGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<CustomPanGestureRecognizer>(
+          () => CustomPanGestureRecognizer(
+            onPanDown: this._onPanDown,
+            onPanUpdate: this._onPanUpdate,
+            onPanEnd: this._onPanEnd,
+          ),
+          (_) {},
+        ),
+      },
+      child: this.child,
+    );
+  }
+}

--- a/lib/src/recognizers/custom_pan_recognizer.dart
+++ b/lib/src/recognizers/custom_pan_recognizer.dart
@@ -1,0 +1,45 @@
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
+
+class CustomPanGestureRecognizer extends OneSequenceGestureRecognizer {
+  final Function(Offset offset) onPanDown;
+  final Function(Offset delta) onPanUpdate;
+  final Function onPanEnd;
+
+  CustomPanGestureRecognizer({
+    required this.onPanDown,
+    required this.onPanUpdate,
+    required this.onPanEnd,
+  });
+
+  @override
+  void addPointer(PointerEvent event) {
+    if (event.original is PointerDownEvent) {
+      this.onPanDown(event.position);
+      this.startTrackingPointer(event.pointer);
+      this.resolve(GestureDisposition.accepted);
+      return;
+    }
+    this.stopTrackingPointer(event.pointer);
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    switch (event.runtimeType) {
+      case PointerMoveEvent:
+        this.onPanUpdate(event.delta);
+        return;
+      case PointerUpEvent:
+        this.onPanEnd(event.position);
+        this.stopTrackingPointer(event.pointer);
+        return;
+    }
+  }
+
+  @override
+  String get debugDescription => 'customPan';
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {}
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -94,7 +94,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crop_your_image
 description: crop_your_image helps your app to embed Widgets for cropping images.
-version: 0.6.0+1
+version: 0.6.1
 homepage: https://github.com/chooyan-eng/crop_your_image
 
 environment:
@@ -22,33 +22,33 @@ dev_dependencies:
 # The following section is specific to Flutter.
 flutter:
 
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
+# To add assets to your package, add an assets section, like this:
+# assets:
+#   - images/a_dot_burr.jpeg
+#   - images/a_dot_ham.jpeg
+#
+# For details regarding assets in packages, see
+# https://flutter.dev/assets-and-images/#from-packages
+#
+# An image asset can refer to one or more resolution-specific "variants", see
+# https://flutter.dev/assets-and-images/#resolution-aware.
 
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages
+# To add custom fonts to your package, add a fonts section here,
+# in this "flutter" section. Each entry in this list should have a
+# "family" key with the font family name, and a "fonts" key with a
+# list giving the asset and other descriptors for the font. For
+# example:
+# fonts:
+#   - family: Schyler
+#     fonts:
+#       - asset: fonts/Schyler-Regular.ttf
+#       - asset: fonts/Schyler-Italic.ttf
+#         style: italic
+#   - family: Trajan Pro
+#     fonts:
+#       - asset: fonts/TrajanPro.ttf
+#       - asset: fonts/TrajanPro_Bold.ttf
+#         weight: 700
+#
+# For details regarding fonts in packages, see
+# https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
### Custom pan recognizer and detector
In some cases there are multiple `GestureRecognizers` in a certain area. This could result in the corner dots becoming unresponsive. 
For example, I have a tab bar and multiple horizontally sliding pages. This would cause the `HorizontalDragGestureRecognizer` always winning in the arena. Because of that you could not drag the corners horizontally, only vertically.
This PR fixes that issue.

### Custom loading widget
Apps often use their own loading overlay, so it is now possible to replace the default `CircularProgressIndicator`