### PR TITLE
Widget Testが失敗する問題を修正

### DIFF
--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,30 +1,22 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+import 'dart:io';
 
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
-
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+  testWidgets('Show Crop', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CropSample(),
+        ),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(Crop), findsOneWidget);
   });
 }

--- a/lib/crop_your_image.dart
+++ b/lib/crop_your_image.dart
@@ -1,5 +1,6 @@
 library crop_your_image;
 
+import 'dart:io' if (dart.library.html) 'dart:html';
 import 'dart:math';
 import 'dart:typed_data';
 

--- a/lib/crop_your_image.dart
+++ b/lib/crop_your_image.dart
@@ -1,6 +1,6 @@
 library crop_your_image;
 
-import 'dart:io' if (dart.library.html) 'dart:html';
+import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 

--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -439,7 +439,10 @@ class _CropEditorState extends State<_CropEditor> {
   @override
   Widget build(BuildContext context) {
     return _isImageLoading
-        ? Center(child: const CircularProgressIndicator())
+        ? Center(
+            child: !kIsWeb && Platform.environment.containsKey('FLUTTER_TEST')
+                ? SizedBox.shrink()
+                : const CircularProgressIndicator())
         : Stack(
             children: [
               Listener(


### PR DESCRIPTION
Widget Testが失敗する問題(#55)について、`CircularProgressIndicator()` をテスト中は利用しないようにしました。

またWidgetテストも追加しましたのでご確認ください。
