### PR TITLE
added progressIndicator param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.7.3] - 2022.11.15
+* Add `progressIndicator` parameter to pass a Widget indicating progress.
+
 ## [0.7.2] - 2022.03.16
 * Enhanced zooming / panning behavior
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Widget build(BuildContext context) {
 - `onMoved` callback is called when cropping area is moved regardless of its reasons. `newRect` of argument is current `Rect` of cropping area.
 - `onStatusChanged` callback is called when status of Crop is changed.
 - `cornerDotBuilder` is the builder to build Widget placed at corners. The builder passes `size` which widget must follow and `edgeAlignment` which indicates the position.
+- `progressIndicator` is used for showing preparing image to cropped is in progress. Nothing (`SizedBox.shrink()` actually) is shown by default.
 - `interactive` enables _experimental_ feature of moving / zooming images.
 - `fixArea` is the flag if crop area should be fixed.
 

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,30 +1,20 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
-
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+  testWidgets('Show Crop', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CropSample(),
+        ),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(Crop), findsOneWidget);
   });
 }

--- a/lib/crop_your_image.dart
+++ b/lib/crop_your_image.dart
@@ -1,7 +1,6 @@
 library crop_your_image;
 
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -80,6 +80,10 @@ class Crop extends StatelessWidget {
   /// [false] by default.
   final bool fixArea;
 
+  /// [Widget] for showing preparing for image is in progress.
+  /// [SizedBox.shrink()] is used by default.
+  final Widget progressIndicator;
+
   /// * Experimental Feature *
   /// If [true], users can move and zoom image.
   /// [false] by default.
@@ -102,6 +106,7 @@ class Crop extends StatelessWidget {
     this.radius = 0,
     this.cornerDotBuilder,
     this.fixArea = false,
+    this.progressIndicator = const SizedBox.shrink(),
     this.interactive = false,
   })  : assert((initialSize ?? 1.0) <= 1.0,
             'initialSize must be less than 1.0, or null meaning not specified.'),
@@ -132,6 +137,7 @@ class Crop extends StatelessWidget {
             radius: radius,
             cornerDotBuilder: cornerDotBuilder,
             fixArea: fixArea,
+            progressIndicator: progressIndicator,
             interactive: interactive,
           ),
         );
@@ -156,6 +162,7 @@ class _CropEditor extends StatefulWidget {
   final double radius;
   final CornerDotBuilder? cornerDotBuilder;
   final bool fixArea;
+  final Widget progressIndicator;
   final bool interactive;
 
   const _CropEditor({
@@ -175,6 +182,7 @@ class _CropEditor extends StatefulWidget {
     required this.radius,
     this.cornerDotBuilder,
     required this.fixArea,
+    required this.progressIndicator,
     required this.interactive,
   }) : super(key: key);
 
@@ -439,7 +447,7 @@ class _CropEditorState extends State<_CropEditor> {
   @override
   Widget build(BuildContext context) {
     return _isImageLoading
-        ? Center(child: const CircularProgressIndicator())
+        ? Center(child: widget.progressIndicator)
         : Stack(
             children: [
               Listener(


### PR DESCRIPTION
Usage

```
Crop(
  progressIndicator: const CircularProgressIndicator(),
),
```

or 

```
Crop(
  progressIndicator: const Text('preparing image...'),
),
```

This change will fix widget test failure.