### PR TITLE
Add parameter for custom encode function

### DIFF
--- a/lib/crop_your_image.dart
+++ b/lib/crop_your_image.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:image/image.dart' as image;
+import 'package:image/image.dart' as img;
 
 part 'src/crop.dart';
 part 'src/controller.dart';

--- a/lib/src/calculator.dart
+++ b/lib/src/calculator.dart
@@ -15,7 +15,7 @@ abstract class _Calculator {
   double scaleToCover(Size screenSize, Rect imageRect);
 
   /// calculates ratio of [targetImage] and [screenSize]
-  double screenSizeRatio(image.Image targetImage, Size screenSize);
+  double screenSizeRatio(img.Image targetImage, Size screenSize);
 
   /// calculates [Rect] of the result of user moving the cropping area.
   Rect moveRect(Rect original, double deltaX, double deltaY, Rect imageRect) {
@@ -272,7 +272,7 @@ class _HorizontalCalculator extends _Calculator {
   }
 
   @override
-  double screenSizeRatio(image.Image targetImage, Size screenSize) {
+  double screenSizeRatio(img.Image targetImage, Size screenSize) {
     return targetImage.width / screenSize.width;
   }
 }
@@ -314,7 +314,7 @@ class _VerticalCalculator extends _Calculator {
   }
 
   @override
-  double screenSizeRatio(image.Image targetImage, Size screenSize) {
+  double screenSizeRatio(img.Image targetImage, Size screenSize) {
     return targetImage.height / screenSize.height;
   }
 }

--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -193,13 +193,13 @@ class _CropEditor extends StatefulWidget {
 class _CropEditorState extends State<_CropEditor> {
   late CropController _cropController;
   late Rect _rect;
-  image.Image? _targetImage;
+  img.Image? _targetImage;
   late Rect _imageRect;
 
   double? _aspectRatio;
   bool _withCircleUi = false;
   bool _isFitVertically = false;
-  Future<image.Image?>? _lastComputed;
+  Future<img.Image?>? _lastComputed;
 
   bool get _isImageLoading => _lastComputed != null;
 
@@ -689,11 +689,11 @@ class DotControl extends StatelessWidget {
 /// process cropping image.
 /// this method is supposed to be called only via compute()
 Uint8List _doCrop(List<dynamic> cropData) {
-  final originalImage = cropData[0] as image.Image;
+  final originalImage = cropData[0] as img.Image;
   final rect = cropData[1] as Rect;
   return Uint8List.fromList(
-    image.encodePng(
-      image.copyCrop(
+    img.encodePng(
+      img.copyCrop(
         originalImage,
         x: rect.left.toInt(),
         y: rect.top.toInt(),
@@ -707,15 +707,15 @@ Uint8List _doCrop(List<dynamic> cropData) {
 /// process cropping image with circle shape.
 /// this method is supposed to be called only via compute()
 Uint8List _doCropCircle(List<dynamic> cropData) {
-  final originalImage = cropData[0] as image.Image;
+  final originalImage = cropData[0] as img.Image;
   final rect = cropData[1] as Rect;
-  final center = image.Point(
+  final center = img.Point(
     rect.left + rect.width / 2,
     rect.top + rect.height / 2,
   );
   return Uint8List.fromList(
-    image.encodePng(
-      image.copyCropCircle(
+    img.encodePng(
+      img.copyCropCircle(
         originalImage,
         centerX: center.xi,
         centerY: center.yi,
@@ -726,18 +726,18 @@ Uint8List _doCropCircle(List<dynamic> cropData) {
 }
 
 // decode orientation awared Image.
-image.Image _fromByteData(Uint8List data) {
-  final tempImage = image.decodeImage(data);
+img.Image _fromByteData(Uint8List data) {
+  final tempImage = img.decodeImage(data);
   assert(tempImage != null);
 
   // check orientation
   switch (tempImage?.exif.exifIfd.orientation ?? -1) {
     case 3:
-      return image.copyRotate(tempImage!, angle: 180);
+      return img.copyRotate(tempImage!, angle: 180);
     case 6:
-      return image.copyRotate(tempImage!, angle: 90);
+      return img.copyRotate(tempImage!, angle: 90);
     case 8:
-      return image.copyRotate(tempImage!, angle: -90);
+      return img.copyRotate(tempImage!, angle: -90);
   }
   return tempImage!;
 }


### PR DESCRIPTION
When a cropped image is saved, it has always been encoded as a PNG using `encodePng`. This has the disadvantage of not being as compressible as for example JPG.

This pull request adds an `encodeFunction` parameter which by default is `encodePng` to avoid breaking changes. If a jpg output is preferred, this can instead be set to `encodeJpg`. Allowing passing the encode function as a parameter instead of just having a parameter for the file type has the advantage of also making it possible to set the `quality` parameter of `encodeJpg` for example.

Aditionally, having the function as a parameter allow the user to perform aditional processing, such as resizing:

```dart
encodeFunction: (croppedImage) => img.encodeJpg(
  img.copyResize(
    croppedImage,
    width: 500,
    height: 500,
  ),
  quality: 75,
),
```

A side effect of this change is that that there was a conflict with the `image` prefix of the `package:image/image.dart` import, since there is a parameter named image in `Crop` as well. I therefore had to rename the prefix to `img`.

This fixes https://github.com/chooyan-eng/crop_your_image/issues/48