### PR TITLE
feat: add filterQuality

### DIFF
--- a/lib/src/widget/crop.dart
+++ b/lib/src/widget/crop.dart
@@ -140,6 +140,9 @@ class Crop extends StatelessWidget {
   /// builder to place a widget inside the cropping area
   final OverlayBuilder? overlayBuilder;
 
+  /// The rendering quality of the image
+  final FilterQuality filterQuality;
+
   Crop({
     super.key,
     required this.image,
@@ -167,6 +170,7 @@ class Crop extends StatelessWidget {
     ImageParser? imageParser,
     this.scrollZoomSensitivity = 0.05,
     this.overlayBuilder,
+    this.filterQuality = FilterQuality.medium,
   })  : assert((initialSize ?? 1.0) <= 1.0,
             'initialSize must be less than 1.0, or null meaning not specified.'),
         this.imageParser = imageParser ?? defaultImageParser;
@@ -207,6 +211,7 @@ class Crop extends StatelessWidget {
             formatDetector: formatDetector,
             imageParser: imageParser,
             overlayBuilder: overlayBuilder,
+            filterQuality: filterQuality,
           ),
         );
       },
@@ -240,6 +245,7 @@ class _CropEditor extends StatefulWidget {
   final ImageParser imageParser;
   final double scrollZoomSensitivity;
   final OverlayBuilder? overlayBuilder;
+  final FilterQuality filterQuality;
 
   const _CropEditor({
     super.key,
@@ -268,6 +274,7 @@ class _CropEditor extends StatefulWidget {
     required this.imageParser,
     required this.scrollZoomSensitivity,
     this.overlayBuilder,
+    required this.filterQuality,
   });
 
   @override
@@ -571,6 +578,7 @@ class _CropEditorState extends State<_CropEditor> {
                             width: _readyState.imageRect.width,
                             height: _readyState.imageRect.height,
                             fit: BoxFit.contain,
+                            filterQuality: widget.filterQuality,
                           ),
                         ),
                       ],


### PR DESCRIPTION
exposes [filterQuality](https://api.flutter.dev/flutter/widgets/Image/filterQuality.html) of `Image`

My use case:
I want to set `filterQuality` to `FilterQuality.none`, when cropping pixel art. Otherwise the pixel art is blurred.