### PR TITLE
Add clipBehavior configuration to Crop

### DIFF
--- a/lib/src/widget/crop.dart
+++ b/lib/src/widget/crop.dart
@@ -87,6 +87,10 @@ class Crop extends StatelessWidget {
   /// If default dot Widget with different color is needed, [DotControl] is available.
   final CornerDotBuilder? cornerDotBuilder;
 
+  /// [Clip] configuration for Crop editor, especially corner dots.
+  /// [Clip.hardEdge] by default.
+  final Clip clipBehavior;
+
   /// If [true], cropping area is fixed and CANNOT be moved.
   /// [false] by default.
   final bool fixArea;
@@ -129,6 +133,7 @@ class Crop extends StatelessWidget {
     this.baseColor = Colors.white,
     this.radius = 0,
     this.cornerDotBuilder,
+    this.clipBehavior = Clip.hardEdge,
     this.fixArea = false,
     this.progressIndicator = const SizedBox.shrink(),
     this.interactive = false,
@@ -165,6 +170,7 @@ class Crop extends StatelessWidget {
             baseColor: baseColor,
             radius: radius,
             cornerDotBuilder: cornerDotBuilder,
+            clipBehavior: clipBehavior,
             fixArea: fixArea,
             progressIndicator: progressIndicator,
             interactive: interactive,
@@ -194,6 +200,7 @@ class _CropEditor extends StatefulWidget {
   final Color baseColor;
   final double radius;
   final CornerDotBuilder? cornerDotBuilder;
+  final Clip clipBehavior;
   final bool fixArea;
   final Widget progressIndicator;
   final bool interactive;
@@ -206,18 +213,19 @@ class _CropEditor extends StatefulWidget {
     super.key,
     required this.image,
     required this.onCropped,
-    this.aspectRatio,
-    this.initialSize,
-    this.initialAreaBuilder,
-    this.initialArea,
+    required this.aspectRatio,
+    required this.initialSize,
+    required this.initialAreaBuilder,
+    required this.initialArea,
     this.withCircleUi = false,
-    this.controller,
-    this.onMoved,
-    this.onStatusChanged,
-    this.maskColor,
+    required this.controller,
+    required this.onMoved,
+    required this.onStatusChanged,
+    required this.maskColor,
     required this.baseColor,
     required this.radius,
-    this.cornerDotBuilder,
+    required this.cornerDotBuilder,
+    required this.clipBehavior,
     required this.fixArea,
     required this.progressIndicator,
     required this.interactive,
@@ -532,6 +540,7 @@ class _CropEditorState extends State<_CropEditor> {
     return _isImageLoading
         ? Center(child: widget.progressIndicator)
         : Stack(
+            clipBehavior: widget.clipBehavior,
             children: [
               Listener(
                 onPointerDown: (_) => _pointerNum++,


### PR DESCRIPTION
By setting `Clip.none` to `clipBehavior` argument of `Crop`, all the widgets on the crop editor are not clipped even if they are outside of their viewport.

|default|Clip.none|
|-|-|
|<img src="https://github.com/chooyan-eng/crop_your_image/assets/20849526/4f2e6191-124a-42c4-b6b1-89f9253c21db" width=300>|<img src="https://github.com/chooyan-eng/crop_your_image/assets/20849526/6e545c7f-dc03-4e17-9dac-44dae4cd3bed" width=300>|

Note that touch event will not happen if user touches outside of crop editor because of the Flutter's gesture detection system.