### PR TITLE
Fix crash after disposed

### DIFF
--- a/lib/src/widget/crop.dart
+++ b/lib/src/widget/crop.dart
@@ -348,6 +348,11 @@ class _CropEditorState extends State<_CropEditor> {
     );
     _lastComputed = future;
     future.then((parsed) {
+      // check if Crop is still alive
+      if (!mounted) {
+        return;
+      }
+
       // if _parseImageWith() is called again before future completed,
       // just skip and the last future is used.
       if (_lastComputed == future) {


### PR DESCRIPTION
Fixed an error by calling `setState` after `State` is disposed.

Because this error typically happens after asynchronous operation, I just check with `if (!mounted)` right after `.then()` is called rather than always checking before calling `setState`.