### PR TITLE
fix bug that withCircleUi flag doesn't work

### DIFF
--- a/lib/src/widget/crop.dart
+++ b/lib/src/widget/crop.dart
@@ -294,6 +294,8 @@ class _CropEditorState extends State<_CropEditor> {
   void initState() {
     super.initState();
 
+    _withCircleUi = widget.withCircleUi;
+
     // prepare for controller
     _cropController = widget.controller ?? CropController();
     _cropController.delegate = CropControllerDelegate()


### PR DESCRIPTION
`withCircleUi` flag wasn't copied to `_withCircleUi` private field of `_CropEditorState`.

This resulted in the bug that `withCircleUi: true` doesn't show circle crop area.