### PR TITLE
fix image package's ImageFormat enum import

### DIFF
--- a/lib/src/logic/cropper/image_image_cropper.dart
+++ b/lib/src/logic/cropper/image_image_cropper.dart
@@ -10,7 +10,7 @@ import 'package:crop_your_image/src/logic/cropper/image_cropper.dart';
 import 'package:crop_your_image/src/logic/format_detector/format.dart';
 import 'package:crop_your_image/src/logic/shape.dart';
 
-import 'package:image/image.dart';
+import 'package:image/image.dart' hide ImageFormat;
 
 /// an implementation of [ImageCropper] using image package
 class ImageImageCropper extends ImageCropper<Image> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  image: ^4.0.17
+  image: ^4.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The package:image/image.dart has a new enum defined that conflicts with an enum defined in this project. This PR disambiguates the correct import for the ImageImageCropper class. 

package:image/image.dart v4.2.0 is when the new enum was added. 