### PR TITLE
Feature/undo redo

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,6 +61,8 @@ class _CropSampleState extends State<CropSample> {
   var _isCircleUi = false;
   Uint8List? _croppedData;
   var _statusText = '';
+  var _undoEnabled = false;
+  var _redoEnabled = false;
 
   @override
   void initState() {
@@ -153,6 +155,10 @@ class _CropSampleState extends State<CropSample> {
                               viewportRect.bottom - 24,
                             );
                           },
+                          onHistoryChanged: (history) => setState(() {
+                            _undoEnabled = history.undoCount > 0;
+                            _redoEnabled = history.redoCount > 0;
+                          }),
                         ),
                         IgnorePointer(
                           child: Padding(
@@ -237,6 +243,24 @@ class _CropSampleState extends State<CropSample> {
                               }),
                         ],
                       ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          ElevatedButton(
+                            onPressed: _undoEnabled
+                                ? () => _cropController.undo()
+                                : null,
+                            child: Text('UNDO'),
+                          ),
+                          const SizedBox(width: 16),
+                          ElevatedButton(
+                            onPressed: _redoEnabled
+                                ? () => _cropController.redo()
+                                : null,
+                            child: Text('REDO'),
+                          ),
+                        ],
+                      ),
                       const SizedBox(height: 16),
                       Container(
                         width: double.infinity,
@@ -255,7 +279,6 @@ class _CropSampleState extends State<CropSample> {
                           ),
                         ),
                       ),
-                      const SizedBox(height: 40),
                     ],
                   ),
                 ),

--- a/lib/src/widget/controller.dart
+++ b/lib/src/widget/controller.dart
@@ -35,6 +35,12 @@ class CropController {
   /// change [ViewportBasedRect] of crop rect
   /// based on [ImageBasedRect] of original image.
   set area(ImageBasedRect value) => _delegate.onChangeArea(value);
+
+  /// request undo
+  void undo() => _delegate.onUndo();
+
+  /// request redo
+  void redo() => _delegate.onRedo();
 }
 
 /// Delegate of actions from [CropController]
@@ -57,4 +63,10 @@ class CropControllerDelegate {
 
   /// callback that [CropController.area] is changed.
   late ValueChanged<ImageBasedRect> onChangeArea;
+
+  /// callback that [CropController.undo] is called.
+  late VoidCallback onUndo;
+
+  /// callback that [CropController.redo] is called.
+  late VoidCallback onRedo;
 }

--- a/lib/src/widget/history_state.dart
+++ b/lib/src/widget/history_state.dart
@@ -21,33 +21,40 @@ class HistoryState {
   void pushHistory(CropEditorViewState viewState) {
     history.add(viewState);
     redoHistory.clear();
-    onHistoryChanged?.call((history.length, redoHistory.length));
+    onHistoryChanged?.call(
+      (undoCount: history.length, redoCount: redoHistory.length),
+    );
   }
 
   /// request [CropEditorViewState] for undo
   /// this method will pop last history and push to redo history
-  CropEditorViewState? requestUndo() {
+  CropEditorViewState? requestUndo(CropEditorViewState current) {
     if (history.isEmpty) {
       return null;
     }
 
+    redoHistory.add(current);
     final last = history.removeLast();
-    redoHistory.add(last);
-    onHistoryChanged?.call((history.length, redoHistory.length));
+
+    onHistoryChanged?.call(
+      (undoCount: history.length, redoCount: redoHistory.length),
+    );
 
     return last;
   }
 
   /// request [CropEditorViewState] for redo
   /// this method will pop last redo history
-  CropEditorViewState? requestRedo() {
+  CropEditorViewState? requestRedo(CropEditorViewState current) {
     if (redoHistory.isEmpty) {
       return null;
     }
 
+    history.add(current);
     final last = redoHistory.removeLast();
-    history.add(last);
-    onHistoryChanged?.call((history.length, redoHistory.length));
+    onHistoryChanged?.call(
+      (undoCount: history.length, redoCount: redoHistory.length),
+    );
     return last;
   }
 }

--- a/lib/src/widget/history_state.dart
+++ b/lib/src/widget/history_state.dart
@@ -1,0 +1,53 @@
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:crop_your_image/src/widget/crop_editor_view_state.dart';
+import 'package:flutter/foundation.dart';
+
+class HistoryState {
+  HistoryState({required this.onHistoryChanged});
+
+  /// history of crop editor operation for undo
+  /// history is stored when zoom / pan is changed, as well as crop rect moved.
+  @visibleForTesting
+  final List<CropEditorViewState> history = [];
+
+  /// history of crop editor operation for redo
+  @visibleForTesting
+  final List<CropEditorViewState> redoHistory = [];
+
+  final HistoryChangedCallback? onHistoryChanged;
+
+  /// push current view state to history
+  /// this operation will clear redo history
+  void pushHistory(CropEditorViewState viewState) {
+    history.add(viewState);
+    redoHistory.clear();
+    onHistoryChanged?.call((history.length, redoHistory.length));
+  }
+
+  /// request [CropEditorViewState] for undo
+  /// this method will pop last history and push to redo history
+  CropEditorViewState? requestUndo() {
+    if (history.isEmpty) {
+      return null;
+    }
+
+    final last = history.removeLast();
+    redoHistory.add(last);
+    onHistoryChanged?.call((history.length, redoHistory.length));
+
+    return last;
+  }
+
+  /// request [CropEditorViewState] for redo
+  /// this method will pop last redo history
+  CropEditorViewState? requestRedo() {
+    if (redoHistory.isEmpty) {
+      return null;
+    }
+
+    final last = redoHistory.removeLast();
+    history.add(last);
+    onHistoryChanged?.call((history.length, redoHistory.length));
+    return last;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -87,18 +87,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -119,18 +119,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -196,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   xml:
     dependency: transitive
     description:

--- a/test/widget/history_state_test.dart
+++ b/test/widget/history_state_test.dart
@@ -1,0 +1,128 @@
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crop_your_image/src/widget/crop_editor_view_state.dart';
+import 'package:crop_your_image/src/widget/history_state.dart';
+
+void main() {
+  final defaultViewportSize = Size(360, 200);
+  final defaultImageSize = Size(800, 600);
+
+  late HistoryState historyState;
+  late List<History> historyChangedCalls;
+
+  setUp(() {
+    historyChangedCalls = [];
+    historyState = HistoryState(
+      onHistoryChanged: (history) => historyChangedCalls.add(history),
+    );
+  });
+
+  ReadyCropEditorViewState createViewState() {
+    return ReadyCropEditorViewState.prepared(
+      defaultImageSize,
+      viewportSize: defaultViewportSize,
+      scale: 1.0,
+      aspectRatio: null,
+      withCircleUi: false,
+    );
+  }
+
+  test('initial state has empty history', () {
+    expect(historyState.history, isEmpty);
+    expect(historyState.redoHistory, isEmpty);
+  });
+
+  test('pushHistory adds state and clears redo history', () {
+    final state1 = createViewState(scale: 1.0);
+    final state2 = createViewState(scale: 1.5);
+
+    historyState.pushHistory(state1);
+    historyState.pushHistory(state2);
+
+    expect(historyState.history.length, 2);
+    expect(historyState.redoHistory, isEmpty);
+    expect(historyChangedCalls, [
+      (1, 0),
+      (2, 0),
+    ]);
+  });
+
+  test('requestUndo returns last state and moves it to redo history', () {
+    final state1 = createViewState(scale: 1.0);
+    final state2 = createViewState(scale: 1.5);
+
+    historyState.pushHistory(state1);
+    historyState.pushHistory(state2);
+
+    final undoState = historyState.requestUndo();
+
+    expect(undoState, state2);
+    expect(historyState.history.length, 1);
+    expect(historyState.redoHistory.length, 1);
+    expect(historyChangedCalls, [
+      (1, 0),
+      (2, 0),
+      (1, 1),
+    ]);
+  });
+
+  test('requestUndo returns null when history is empty', () {
+    final undoState = historyState.requestUndo();
+
+    expect(undoState, null);
+    expect(historyState.history, isEmpty);
+    expect(historyState.redoHistory, isEmpty);
+    expect(historyChangedCalls, isEmpty);
+  });
+
+  test('requestRedo returns last redo state and moves it to history', () {
+    final state1 = createViewState(scale: 1.0);
+    final state2 = createViewState(scale: 1.5);
+
+    historyState.pushHistory(state1);
+    historyState.pushHistory(state2);
+    historyState.requestUndo(); // Move state2 to redo history
+
+    final redoState = historyState.requestRedo();
+
+    expect(redoState, state2);
+    expect(historyState.history.length, 2);
+    expect(historyState.redoHistory, isEmpty);
+    expect(historyChangedCalls, [
+      (1, 0),
+      (2, 0),
+      (1, 1),
+      (2, 0),
+    ]);
+  });
+
+  test('requestRedo returns null when redo history is empty', () {
+    final redoState = historyState.requestRedo();
+
+    expect(redoState, null);
+    expect(historyState.history, isEmpty);
+    expect(historyState.redoHistory, isEmpty);
+    expect(historyChangedCalls, isEmpty);
+  });
+
+  test('pushing new state clears redo history', () {
+    final state1 = createViewState(scale: 1.0);
+    final state2 = createViewState(scale: 1.5);
+    final state3 = createViewState(scale: 2.0);
+
+    historyState.pushHistory(state1);
+    historyState.pushHistory(state2);
+    historyState.requestUndo(); // Move state2 to redo history
+    historyState.pushHistory(state3); // Should clear redo history
+
+    expect(historyState.history.length, 2);
+    expect(historyState.redoHistory, isEmpty);
+    expect(historyChangedCalls, [
+      (1, 0),
+      (2, 0),
+      (1, 1),
+      (2, 0),
+    ]);
+  });
+}


### PR DESCRIPTION
close: #40

Added undo/redo feature.

Users can use this feature by calling `controller.undo()` or `controller.redo()`. They can also retrieve the undo/redo state by `onHistoryChanged()` callback of `Crop` constructor.

https://github.com/user-attachments/assets/ce34b9f5-e258-4405-881b-ba362274b35c

