### PR TITLE
fix: state goes back to preparing when didChangeDependencies called

### DIFF
--- a/lib/src/widget/crop.dart
+++ b/lib/src/widget/crop.dart
@@ -321,12 +321,6 @@ class _CropEditorState extends State<_CropEditor> {
 
   @override
   void didChangeDependencies() {
-    _viewState = PreparingCropEditorViewState(
-      viewportSize: MediaQuery.of(context).size,
-      withCircleUi: widget.withCircleUi,
-      aspectRatio: widget.aspectRatio,
-    );
-
     /// parse image with given parser and format detector
     _parseImageWith(
       parser: widget.imageParser,
@@ -402,12 +396,18 @@ class _CropEditorState extends State<_CropEditor> {
         _lastImage == image &&
         _lastFormatDetector == formatDetector) {
       // no change
-      return null;
+      return _parsedImageDetail;
     }
 
     _lastParser = parser;
     _lastFormatDetector = formatDetector;
     _lastImage = image;
+
+    _viewState = PreparingCropEditorViewState(
+      viewportSize: MediaQuery.of(context).size,
+      withCircleUi: widget.withCircleUi,
+      aspectRatio: widget.aspectRatio,
+    );
 
     final format = formatDetector?.call(image);
     final future = compute(


### PR DESCRIPTION
Bug fixed that state goes back to `PreparingCropEditorState` when didChangeDependencies is called (e.g. when rebuild happens with different constraints) without initialize operation and never comes back to `ReadyCropEditorState`.