### PR TITLE
Respect original format by default

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:crop_your_image/crop_your_image.dart';
-import 'package:example/my_cropper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:crop_your_image/crop_your_image.dart';
+import 'package:example/my_cropper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 

--- a/example/lib/my_cropper.dart
+++ b/example/lib/my_cropper.dart
@@ -1,0 +1,54 @@
+import 'dart:ui';
+
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:image/image.dart' as image hide ImageFormat;
+
+class MyImageCropper extends ImageCropper<image.Image> {
+  const MyImageCropper();
+  @override
+  RectValidator<image.Image> get rectValidator => defaultRectValidator;
+
+  @override
+  RectCropper<image.Image> get rectCropper => _rectCropper;
+
+  @override
+  CircleCropper<image.Image> get circleCropper => _circleCropper;
+}
+
+final RectCropper<image.Image> _rectCropper = (
+  image.Image original, {
+  required Offset topLeft,
+  required Size size,
+  required ImageFormat? outputFormat,
+}) {
+  /// crop image with low quality
+  return image.encodeJpg(
+    quality: 10,
+    image.copyCrop(
+      original,
+      x: topLeft.dx.toInt(),
+      y: topLeft.dy.toInt(),
+      width: size.width.toInt(),
+      height: size.height.toInt(),
+    ),
+  );
+};
+
+final CircleCropper<image.Image> _circleCropper = (
+  image.Image original, {
+  required Offset center,
+  required double radius,
+  required ImageFormat? outputFormat,
+}) {
+  /// crop image with low quality
+  /// note: jpg can't cropped circle
+  return image.encodeJpg(
+    quality: 10,
+    image.copyCropCircle(
+      original,
+      centerX: center.dx.toInt(),
+      centerY: center.dy.toInt(),
+      radius: radius.toInt(),
+    ),
+  );
+};

--- a/lib/crop_your_image.dart
+++ b/lib/crop_your_image.dart
@@ -1,13 +1,12 @@
 import 'package:crop_your_image/src/logic/cropper/image_image_cropper.dart';
-import 'package:crop_your_image/src/logic/format_detector/format_detector.dart';
+import 'package:crop_your_image/src/logic/cropper/legacy_image_image_cropper.dart';
+import 'package:crop_your_image/src/logic/format_detector/default_format_detector.dart';
 import 'package:crop_your_image/src/logic/parser/image_image_parser.dart';
 
 export 'src/widget/widget.dart';
 export 'src/logic/logic.dart';
 
 final defaultImageParser = imageImageParser;
-
-// TODO(chooyan-eng): implement format detector if possible
-const FormatDetector? defaultFormatDetector = null;
-
+final defaultFormatDetector = imageFormatDetector;
 const defaultImageCropper = ImageImageCropper();
+const legacyImageCropper = LegacyImageImageCropper();

--- a/lib/src/logic/cropper/default_rect_validator.dart
+++ b/lib/src/logic/cropper/default_rect_validator.dart
@@ -1,0 +1,25 @@
+import 'dart:ui';
+
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:crop_your_image/src/logic/cropper/errors.dart';
+import 'package:image/image.dart';
+
+/// default implementation of [RectValidator]
+/// this checks if the rect is inside the image, not negative, and not negative size
+final RectValidator<Image> defaultRectValidator =
+    (Image original, Offset topLeft, Offset bottomRight) {
+  if (topLeft.dx.toInt().isNegative ||
+      topLeft.dy.toInt().isNegative ||
+      bottomRight.dx.toInt().isNegative ||
+      bottomRight.dy.toInt().isNegative ||
+      topLeft.dx.toInt() > original.width ||
+      topLeft.dy.toInt() > original.height ||
+      bottomRight.dx.toInt() > original.width ||
+      bottomRight.dy.toInt() > original.height) {
+    return InvalidRectError(topLeft: topLeft, bottomRight: bottomRight);
+  }
+  if (topLeft.dx > bottomRight.dx || topLeft.dy > bottomRight.dy) {
+    return NegativeSizeError(topLeft: topLeft, bottomRight: bottomRight);
+  }
+  return null;
+};

--- a/lib/src/logic/cropper/image_cropper.dart
+++ b/lib/src/logic/cropper/image_cropper.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -13,7 +14,55 @@ abstract class ImageCropper<T> {
     required T original,
     required Offset topLeft,
     required Offset bottomRight,
-    ImageFormat outputFormat,
-    ImageShape shape,
-  });
+    ImageFormat? outputFormat,
+    ImageShape shape = ImageShape.rectangle,
+  }) async {
+    final error = rectValidator(original, topLeft, bottomRight);
+    if (error != null) {
+      throw error;
+    }
+
+    final size = Size(
+      bottomRight.dx - topLeft.dx,
+      bottomRight.dy - topLeft.dy,
+    );
+
+    return switch (shape) {
+      ImageShape.rectangle => rectCropper(
+          original,
+          topLeft: topLeft,
+          size: size,
+          outputFormat: outputFormat,
+        ),
+      ImageShape.circle => circleCropper(
+          original,
+          center: Offset(
+            topLeft.dx + size.width / 2,
+            topLeft.dy + size.height / 2,
+          ),
+          radius: min(size.width, size.height) / 2,
+          outputFormat: outputFormat,
+        ),
+    };
+  }
+
+  RectValidator<T> get rectValidator;
+  RectCropper<T> get rectCropper;
+  CircleCropper<T> get circleCropper;
 }
+
+typedef RectValidator<T> = Error? Function(
+    T original, Offset topLeft, Offset bottomRight);
+typedef RectCropper<T> = Uint8List Function(
+  T original, {
+  required Offset topLeft,
+  required Size size,
+  required ImageFormat? outputFormat,
+});
+
+typedef CircleCropper<T> = Uint8List Function(
+  T original, {
+  required Offset center,
+  required double radius,
+  required ImageFormat? outputFormat,
+});

--- a/lib/src/logic/cropper/legacy_image_image_cropper.dart
+++ b/lib/src/logic/cropper/legacy_image_image_cropper.dart
@@ -1,4 +1,3 @@
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:crop_your_image/crop_your_image.dart';
@@ -6,14 +5,16 @@ import 'package:crop_your_image/crop_your_image.dart';
 import 'package:image/image.dart' hide ImageFormat;
 
 /// an implementation of [ImageCropper] using image package
-class ImageImageCropper extends ImageCropper<Image> {
-  const ImageImageCropper();
+/// this implementation is legacy that behaves the same as the version 1.1.0 or earlier
+/// meaning that it doesn't respect the outputFormat and always encode result as png
+class LegacyImageImageCropper extends ImageCropper<Image> {
+  const LegacyImageImageCropper();
 
   @override
-  RectCropper<Image> get rectCropper => defaultRectCropper;
+  RectCropper<Image> get rectCropper => legacyRectCropper;
 
   @override
-  CircleCropper<Image> get circleCropper => defaultCircleCropper;
+  CircleCropper<Image> get circleCropper => legacyCircleCropper;
 
   @override
   RectValidator<Image> get rectValidator => defaultRectValidator;
@@ -21,13 +22,13 @@ class ImageImageCropper extends ImageCropper<Image> {
 
 /// process cropping image.
 /// this method is supposed to be called only via compute()
-final RectCropper<Image> defaultRectCropper = (
+final RectCropper<Image> legacyRectCropper = (
   Image original, {
   required Offset topLeft,
   required Size size,
   required ImageFormat? outputFormat,
 }) {
-  return _findCropFunc(outputFormat)(
+  return encodePng(
     copyCrop(
       original,
       x: topLeft.dx.toInt(),
@@ -40,13 +41,13 @@ final RectCropper<Image> defaultRectCropper = (
 
 /// process cropping image with circle shape.
 /// this method is supposed to be called only via compute()
-final CircleCropper<Image> defaultCircleCropper = (
+final CircleCropper<Image> legacyCircleCropper = (
   Image original, {
   required Offset center,
   required double radius,
   required ImageFormat? outputFormat,
 }) {
-  return _findCropFunc(outputFormat)(
+  return encodePng(
     copyCropCircle(
       original,
       centerX: center.dx.toInt(),
@@ -55,13 +56,3 @@ final CircleCropper<Image> defaultCircleCropper = (
     ),
   );
 };
-
-Uint8List Function(Image) _findCropFunc(ImageFormat? outputFormat) {
-  return switch (outputFormat) {
-    ImageFormat.bmp => encodeBmp,
-    ImageFormat.ico => encodeIco,
-    ImageFormat.jpeg => encodeJpg,
-    ImageFormat.png => encodePng,
-    _ => encodePng,
-  };
-}

--- a/lib/src/logic/format_detector/default_format_detector.dart
+++ b/lib/src/logic/format_detector/default_format_detector.dart
@@ -1,0 +1,17 @@
+import 'dart:typed_data';
+
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:image/image.dart' as img;
+
+final FormatDetector imageFormatDetector = (Uint8List data) {
+  final format = img.findFormatForData(data);
+
+  return switch (format) {
+    img.ImageFormat.png => ImageFormat.png,
+    img.ImageFormat.jpg => ImageFormat.jpeg,
+    img.ImageFormat.webp => ImageFormat.webp,
+    img.ImageFormat.bmp => ImageFormat.bmp,
+    img.ImageFormat.ico => ImageFormat.ico,
+    _ => ImageFormat.png,
+  };
+};

--- a/lib/src/logic/logic.dart
+++ b/lib/src/logic/logic.dart
@@ -1,4 +1,5 @@
 export 'cropper/image_cropper.dart';
+export 'cropper/default_rect_validator.dart';
 export 'format_detector/format_detector.dart';
 export 'format_detector/format.dart';
 export 'parser/image_parser.dart';

--- a/lib/src/widget/crop.dart
+++ b/lib/src/widget/crop.dart
@@ -172,13 +172,14 @@ class Crop extends StatelessWidget {
     this.interactive = false,
     this.willUpdateScale,
     this.onHistoryChanged,
-    this.formatDetector = defaultFormatDetector,
+    FormatDetector? formatDetector,
     this.imageCropper = defaultImageCropper,
     ImageParser? imageParser,
     this.scrollZoomSensitivity = 0.05,
     this.overlayBuilder,
     this.filterQuality = FilterQuality.medium,
-  }) : this.imageParser = imageParser ?? defaultImageParser;
+  })  : this.imageParser = imageParser ?? defaultImageParser,
+        this.formatDetector = formatDetector ?? defaultFormatDetector;
 
   @override
   Widget build(BuildContext context) {
@@ -761,14 +762,13 @@ FutureOr<Uint8List> _cropFunc(List<dynamic> args) {
   final originalImage = args[1];
   final rect = args[2] as Rect;
   final withCircleShape = args[3] as bool;
-
-  // TODO(chooyan-eng): currently always PNG
-  // final outputFormat = args[4] as ImageFormat?;
+  final outputFormat = args[4] as ImageFormat;
 
   return cropper.call(
     original: originalImage,
     topLeft: Offset(rect.left, rect.top),
     bottomRight: Offset(rect.right, rect.bottom),
     shape: withCircleShape ? ImageShape.circle : ImageShape.rectangle,
+    outputFormat: outputFormat,
   );
 }

--- a/test/widget/helper.dart
+++ b/test/widget/helper.dart
@@ -1,10 +1,4 @@
-import 'dart:async';
-
-import 'dart:typed_data';
-
 import 'package:crop_your_image/src/logic/cropper/image_cropper.dart';
-import 'package:crop_your_image/src/logic/format_detector/format.dart';
-import 'package:crop_your_image/src/logic/shape.dart';
 import 'package:flutter/material.dart';
 
 Widget withMaterial(Widget widget) {
@@ -20,13 +14,11 @@ Widget withMaterial(Widget widget) {
 /// [ImageCropper] that always fails
 class FailureCropper extends ImageCropper {
   @override
-  Future<Uint8List> call({
-    required dynamic original,
-    required Offset topLeft,
-    required Offset bottomRight,
-    ImageFormat outputFormat = ImageFormat.jpeg,
-    ImageShape shape = ImageShape.rectangle,
-  }) async {
-    throw Error();
-  }
+  CircleCropper get circleCropper => throw UnimplementedError();
+
+  @override
+  RectCropper get rectCropper => throw UnimplementedError();
+
+  @override
+  RectValidator get rectValidator => throw Error();
 }


### PR DESCRIPTION
This introduces breaking changes that:

- `Crop` respect the original image format as much as possible. This means if the original format is PNG, cropped image will also PNG.
- How to implement `imageCropper` is changed. Instead of implementing `call()`, you must override `rectValidator `, `rectCropper`, and `circleCropper` separately.